### PR TITLE
Clean up pre-reqs.ps1

### DIFF
--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -38,8 +38,5 @@ if (-not (test-path $isoSavePath)) {
 }
 
 Write-Host "Grab a x64 ISO from https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022 and save it in the ISOs folder."
-
-Install-Module -Name Convert-WindowsImage
-
 Write-Host "If the above fails to install Convert-WindowsImage then download it from https://github.com/x0nn/Convert-WindowsImage"
 Write-Host "Save it in $VMStuff\Convert-WindowsImage (from PS Gallery)"

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -4,16 +4,7 @@ $IsoSavePath = "$VMStuff\ISOs\Windows Server 2022 (20348.169.210806-2348.fe_rele
 $VMSwitchName = "Testing"
 
 Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
-Install-PackageProvider Nuget –force –verbose
-# Install all modules up front before lengthy download
-$RequiredModules = @(
-    "PowerShellGet"
-    "Hyper-V"
-    "Convert-WindowsImage"
-)
-foreach ($module in $RequiredModules) {
-    Install-Module –Name $module –Force –Verbose
-}
+
 
 try {
     set-vmswitch $VMSwitchName -AllowManagementOS $true -verbose

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -1,4 +1,4 @@
-﻿$ErrorActionPreference = Stop
+$ErrorActionPreference = "Stop"
 $VMStuff="C:\VM_Stuff_Share"
 $IsoSavePath = "$VMStuff\ISOs\Windows Server 2022 (20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us).iso"
 $VMSwitchName = "Testing"

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -28,8 +28,8 @@ try {
 }
 
 
-New-Item $VMStuff\Lab -ItemType Directory
-New-Item $VMStuff\ISOs -ItemType Directory
+New-Item $VMStuff\Lab -ItemType Directory -force
+New-Item $VMStuff\ISOs -ItemType Directory -force
 Set-Location $VMStuff\ISOs
 
 # avoid re-downloading unnecessarily asscript may need to be re-run elevated and we don't want to trigger an overwrite / re-download of 5GB for no reason

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -19,7 +19,10 @@ New-Item $VMStuff\Lab -ItemType Directory
 New-Item $VMStuff\ISOs -ItemType Directory
 Set-Location $VMStuff\ISOs
 
-Invoke-WebRequest -Uri "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso" -OutFile "$ISOSavePath"
+# avoid re-downloading unnecessarily asscript may need to be re-run elevated and we don't want to trigger an overwrite / re-download of 5GB for no reason
+if (-not (test-path $isoSavePath)) {
+    Invoke-WebRequest -Uri "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso" -OutFile $IsoSavePath
+}
 
 Write-Host "Grab a x64 ISO from https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022 and save it in the ISOs folder."
 

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -1,4 +1,5 @@
-﻿$VMStuff="C:\VM_Stuff_Share"
+﻿$ErrorActionPreference = Stop
+$VMStuff="C:\VM_Stuff_Share"
 $IsoSavePath = "$VMStuff\ISOs\Windows Server 2022 (20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us).iso"
 
 Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -1,4 +1,4 @@
-$ErrorActionPreference = "Stop"
+﻿$ErrorActionPreference = "Stop"
 $VMStuff="C:\VM_Stuff_Share"
 $IsoSavePath = "$VMStuff\ISOs\Windows Server 2022 (20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us).iso"
 $VMSwitchName = "Testing"
@@ -32,3 +32,5 @@ if (-not (test-path $isoSavePath)) {
     }
 }
 write-host "ISO saved under $ISOSavePath."
+
+invoke-webrequest -uri "https://raw.githubusercontent.com/x0nn/Convert-WindowsImage/refs/heads/main/Convert-WindowsImage.ps1" -outfile "$VMStuff\Lab\Convert-WindowsImage.ps1" -verbose

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -1,10 +1,12 @@
-﻿New-VMSwitch -Name "Testing" -NetAdapterName "Ethernet" ; Set-VMSwitch -Name Testing -AllowManagementOS $true
+﻿$VMStuff="C:\VM_Stuff_Share"
+$IsoSavePath = "$VMStuff\ISOs\Windows Server 2022 (20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us).iso"
 
-New-Item C:\VM_Stuff_Share\Lab -ItemType Directory
-New-Item C:\VM_Stuff_Share\ISOs -ItemType Directory
-Set-Location C:\VM_Stuff_Share\ISOs
+New-VMSwitch -Name "Testing" -NetAdapterName "Ethernet" ; Set-VMSwitch -Name Testing -AllowManagementOS $true
+New-Item $VMStuff\Lab -ItemType Directory
+New-Item $VMStuff\ISOs -ItemType Directory
+Set-Location $VMStuff\ISOs
 
-Invoke-WebRequest -Uri "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso" -OutFile "C:\VM_Stuff_Share\ISOs\Windows Server 2022 (20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us).iso"
+Invoke-WebRequest -Uri "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso" -OutFile "$ISOSavePath"
 
 Write-Host "Grab a x64 ISO from https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022 and save it in the ISOs folder."
 
@@ -13,4 +15,4 @@ Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 Install-Module -Name Convert-WindowsImage
 
 Write-Host "If the above fails to install Convert-WindowsImage then download it from https://github.com/x0nn/Convert-WindowsImage"
-Write-Host "Save it in C:\VM_Stuff_Share\Convert-WindowsImage (from PS Gallery)"
+Write-Host "Save it in $VMStuff\Convert-WindowsImage (from PS Gallery)"

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -23,9 +23,12 @@ Set-Location $VMStuff\ISOs
 
 # avoid re-downloading unnecessarily asscript may need to be re-run elevated and we don't want to trigger an overwrite / re-download of 5GB for no reason
 if (-not (test-path $isoSavePath)) {
-    Invoke-WebRequest -Uri "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso" -OutFile $IsoSavePath
+    write-host "ISO previously downloaded; If you have issues please delete it and re-run to re-download the file."
+} else {
+    try {
+        Invoke-WebRequest -Uri "https://1software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso" -OutFile $IsoSavePath
+    } catch {
+        Write-Host "ISO download failed, please downlod a x64 ISO from https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022 and save it in the ISOs folder.`r`n($ISOSavePath)"
+    }
 }
-
-Write-Host "Grab a x64 ISO from https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022 and save it in the ISOs folder."
-Write-Host "If the above fails to install Convert-WindowsImage then download it from https://github.com/x0nn/Convert-WindowsImage"
-Write-Host "Save it in $VMStuff\Convert-WindowsImage (from PS Gallery)"
+write-host "ISO saved under $ISOSavePath."

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -1,6 +1,8 @@
 ﻿$VMStuff="C:\VM_Stuff_Share"
 $IsoSavePath = "$VMStuff\ISOs\Windows Server 2022 (20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us).iso"
 
+Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
+
 New-VMSwitch -Name "Testing" -NetAdapterName "Ethernet" ; Set-VMSwitch -Name Testing -AllowManagementOS $true
 New-Item $VMStuff\Lab -ItemType Directory
 New-Item $VMStuff\ISOs -ItemType Directory
@@ -9,8 +11,6 @@ Set-Location $VMStuff\ISOs
 Invoke-WebRequest -Uri "https://software-static.download.prss.microsoft.com/sg/download/888969d5-f34g-4e03-ac9d-1f9786c66749/SERVER_EVAL_x64FRE_en-us.iso" -OutFile "$ISOSavePath"
 
 Write-Host "Grab a x64 ISO from https://www.microsoft.com/en-us/evalcenter/download-windows-server-2022 and save it in the ISOs folder."
-
-Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
 
 Install-Module -Name Convert-WindowsImage
 

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -18,9 +18,7 @@ try {
     }
 }
 
-
-New-Item $VMStuff\Lab -ItemType Directory -force
-New-Item $VMStuff\ISOs -ItemType Directory -force
+@("Lab", "ISOs") | foreach-object {New-Item "$VMStuff\$_" -ItemType Directory -force | out-null}
 Set-Location $VMStuff\ISOs
 
 # avoid re-downloading unnecessarily asscript may need to be re-run elevated and we don't want to trigger an overwrite / re-download of 5GB for no reason

--- a/Pre-reqs.ps1
+++ b/Pre-reqs.ps1
@@ -2,6 +2,17 @@
 $IsoSavePath = "$VMStuff\ISOs\Windows Server 2022 (20348.169.210806-2348.fe_release_svc_refresh_SERVER_EVAL_x64FRE_en-us).iso"
 
 Enable-WindowsOptionalFeature -Online -FeatureName Microsoft-Hyper-V -All
+Install-PackageProvider Nuget –force –verbose
+# Install all modules up front before lengthy download
+$RequiredModules = @(
+    "PowerShellGet"
+    "Hyper-V"
+    "Convert-WindowsImage"
+)
+foreach ($module in $RequiredModules) {
+    Install-Module –Name $module –Force –Verbose
+}
+
 
 New-VMSwitch -Name "Testing" -NetAdapterName "Ethernet" ; Set-VMSwitch -Name Testing -AllowManagementOS $true
 New-Item $VMStuff\Lab -ItemType Directory


### PR DESCRIPTION
The first time I ran pre-reqs.ps1, it encountered issues in a number of places:

1. My adapter is not called "Ethernet", so the VMSwitch call failed
2. Convert-WindowsImage fails to install from psgallery, and is apparently outdated
3. Hyper-V is installed after the attempt to create the VMSwitch, so new-vmswitch won't work the first time
4. the 5GB ISO will attempt to re-download each time you run this, regardless of whether it's been done before
5. Errors are generated on folder creation if the folders already exist

This PR keeps most of the same logic, but with a little more error handling and logical order to make it simpler to resolve prereqs. The only substantive change is getting rid of `install-module` and instead simply downloading the referenced convert-windowsimage.ps1 directly from github.